### PR TITLE
Create a files folder if it does not exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,8 @@ UltraShare has detected a legacy 1.x database in the current folder. Please foll
     fs.mkdirSync("./db");
 }
 
+if (!fs.existsSync("./files/")) fs.mkdirSync("./files");
+
 global.fileDB = new DB("./db/files.json");
 global.apiKeyDB = new DB("./db/apikeys.json");
 global.userDB = new DB("./db/users.json");


### PR DESCRIPTION
Currently, UltraShare does not mandate the existance of a /files/ directory which will result in a crash when you try to upload a file